### PR TITLE
Try to resolve $BASH_SOURCE using readlink -e

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -61,11 +61,11 @@ R           Debug - Repeat last command without contacting server
 x           Debug - Turn on Bash trace (set -x) output
 "
 
+SELF_PATH=$(readlink -e "$BASH_SOURCE") || SELF_PATH=$BASH_SOURCE
 
 # source bash+ :std
-source "${BASH_SOURCE%/*}/git-hub.d/bash+.bash"
+source "${SELF_PATH%/*}/git-hub.d/bash+.bash"
 bash+:import :std can
-
 
 #------------------------------------------------------------------------------
 main() {
@@ -763,7 +763,7 @@ init-env() {
 
   : "${GIT_HUB_API_URI:=https://api.github.com}"
 
-  : "${GIT_HUB_EXEC_PATH:="$(dirname "${BASH_SOURCE[0]}")"}"
+  : "${GIT_HUB_EXEC_PATH:="$(dirname "${SELF_PATH[0]}")"}"
   : "${GIT_HUB_EXT_PATH:=$GIT_HUB_EXEC_PATH/git-hub.d}"
 
   : "${GIT_HUB_USER_DIR:=$HOME/.git-hub}"


### PR DESCRIPTION
If you use a symlink to git-hub command, it will fail to locate the bash+
dependency because it gets the symlink's directory instead of the
file's.
This attempt to resolve the symlink before doing so but since it uses
a GNU readlink options, it falls back to the previous behavior if it
fails.
