### PR TITLE
Strip excess `'`s from default prompt message

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -1158,7 +1158,7 @@ abort() { echo "Abort: $1" >&2; return 1; }
 prompt() {
   local msg answer default yn=false password=false
   case $# in
-    0) msg="${prompt_msg:-'Press <ENTER> to continue, or <CTL>-C to exit.'}" ;;
+    0) msg="${prompt_msg:-Press <ENTER> to continue, or <CTL>-C to exit.}" ;;
     1)
       msg="$1"
       if [[ "$msg" =~ \[yN\] ]]; then


### PR DESCRIPTION
In the `prompt` function in `lib/git-hub`, the default prompt message is
specified as the default value of a `:-`-form Bash parameter expansion.

This default value was wrapped in single quotation marks (instances of
U+0027 APOSTROPHE — `'`), which were taken literally by Bash, resulting
in the prompt message displayed to the user being wrapped in these same
quotation marks — e.g.:

```
> Would you like start the automated 'setup' process right now? (Do
> it!)
>
> 'Press <ENTER> to continue, or <CTL>-C to exit.'
```

This commit deletes these quotation marks, resulting in, e.g.:

```
> Would you like start the automated 'setup' process right now? (Do
> it!)
>
> Press <ENTER> to continue, or <CTL>-C to exit.
```
