### PR TITLE
Clarify new PRs’ sources and targets

### DIFF
--- a/cmd/git-hub-pull
+++ b/cmd/git-hub-pull
@@ -27,7 +27,12 @@ command:pull-request() {
   local url="/repos/$owner/$repo/pulls"
 
   editor-title-body "
-# New GitHub Pull Request for
+# New GitHub Pull Request
+#
+# Requesting that...
+#   repo: $(git config --get "remote.${remote_name}.url")
+#   branch: $branch_name
+# ...be pulled into...
 #   repo: git@github.com:$owner/$repo
 #   branch: $branch
 #


### PR DESCRIPTION
In the text with which `git hub pull-request` pre-populates the pull
request message, clarify which repository and branch is the source and
which is the target.

Previously, the following (e.g.) was shown:

```
> New GitHub Pull Request for
>   repo: git@github.com:ingydotnet/git-hub
>   branch: master
```

When I first saw this, I didn’t know whether this referred to the source
or target (and thus, whether I had given the correct arguments) until I
read the script.

Now, the following (e.g.) should be shown:

```
> New GitHub Pull Request
>
> Requesting that...
>   repo: git@github.com:8573/git-hub.git
>   branch: 8573/clarify-new-pr-source-and-target/1
> ...be pulled into...
>   repo: git@github.com:ingydotnet/git-hub
>   branch: master
```

Note: One may notice that the source repository resource-locator ends
with `.git` and the target repository resource-locator doesn’t. This is
just because that’s what I set as the resource-locator of my `fork`
remote; as far as GitHub cares, the `.git` extension doesn’t matter.
