### PR TITLE
"git hub url" now returns https:// url to github instead of http://

### DIFF
--- a/lib/git-hub.d/git-hub-url
+++ b/lib/git-hub.d/git-hub-url
@@ -19,7 +19,7 @@ command:url() {
 
   get-args '?owner:get-user/repo:get-repo'
 
-  url="http://github.com/$owner/$repo"
+  url="https://github.com/$owner/$repo"
 
   if [ -n "$path" ]; then
     branch="$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
Fixes `git hub url` to show `https://` instead of `http://`.
