### PR TITLE
s/type -f/type -t/ to check for __gitcomp function

### DIFF
--- a/lib/git-hub.d/init
+++ b/lib/git-hub.d/init
@@ -11,7 +11,7 @@ if [[ "$GIT_HUB_ROOT" =~ ^/ ]]; then
 
   export PATH="$GIT_HUB_ROOT/lib:$PATH"
   export MANPATH="$GIT_HUB_ROOT/man:$MANPATH"
-  if [ "$(type -f __gitcomp 2> /dev/null)" != function ]; then
+  if [ "$(type -t __gitcomp 2> /dev/null)" != function ]; then
     if [ -e /etc/bash_completion.d/git ]; then
       source /etc/bash_completion.d/git
     else


### PR DESCRIPTION
In `lib/git-hub.d/init`, to check for the availability of a `__gitcomp`
Bash function, use `type -t __gitcomp` rather than `type -f __gitcomp`.

From my limited testing, `type -t` appears to give the desired output,
whereas `type -f` would not.
