### PR TITLE
Load Bash compl even if `__gitcomp` already exists

### DIFF
--- a/lib/git-hub.d/init
+++ b/lib/git-hub.d/init
@@ -17,8 +17,8 @@ if [[ "$GIT_HUB_ROOT" =~ ^/ ]]; then
     else
       source "$GIT_HUB_ROOT/lib/git-hub.d/git-completion"
     fi
-    source "$GIT_HUB_ROOT/lib/git-hub.d/completion"
   fi
+  source "$GIT_HUB_ROOT/lib/git-hub.d/completion"
 else
   echo "source the absolute path of '$GIT_HUB_ROOT'"
 fi


### PR DESCRIPTION
In `lib/git-hub.d/init`, load the Bash completion facilities for `git
hub` regardless of whether the `__gitcomp` Bash function, defined by the
standard Git completion script, was already available without
`lib/git-hub.d/init` needing to source the standard Git completion
script.

Previously, the Bash completion facilities for `git hub` would only be
loaded if `__gitcomp` was not available prior to `lib/git-hub.d/init`’s
execution, which did not seem to me to be the desired behavior.
