### PR TITLE
`lib/git-hub.d/init`: Load Bash compl only in Bash

### DIFF
--- a/lib/git-hub.d/init
+++ b/lib/git-hub.d/init
@@ -11,14 +11,20 @@ if [[ "$GIT_HUB_ROOT" =~ ^/ ]]; then
 
   export PATH="$GIT_HUB_ROOT/lib:$PATH"
   export MANPATH="$GIT_HUB_ROOT/man:$MANPATH"
-  if [ "$(type -t __gitcomp 2> /dev/null)" != function ]; then
-    if [ -e /etc/bash_completion.d/git ]; then
-      source /etc/bash_completion.d/git
-    else
-      source "$GIT_HUB_ROOT/lib/git-hub.d/git-completion"
+
+  # Completion facilities
+  if [[ -n ${BASH_VERSION-} ]]; then
+    # Bash
+    if [ "$(type -t __gitcomp 2> /dev/null)" != function ]; then
+      if [ -e /etc/bash_completion.d/git ]; then
+	source /etc/bash_completion.d/git
+      else
+	source "$GIT_HUB_ROOT/lib/git-hub.d/git-completion"
+      fi
     fi
+    source "$GIT_HUB_ROOT/lib/git-hub.d/completion"
   fi
-  source "$GIT_HUB_ROOT/lib/git-hub.d/completion"
+
 else
   echo "source the absolute path of '$GIT_HUB_ROOT'"
 fi


### PR DESCRIPTION
In `lib/git-hub.d/init`, load the Bash completion facilities for `git
hub` (and for `git`) only if running under Bash (a status which is
assumed to be true if the shell parameter `BASH_VERSION` is non-null).

(Note: the diff is mostly increased indentation; it might look
friendlier with `--ignore-space-change` (`-b`).)
