### PR TITLE
git hub url should show branch in the URL

### DIFF
--- a/lib/git-hub.d/git-hub-url
+++ b/lib/git-hub.d/git-hub-url
@@ -18,17 +18,11 @@ command:url() {
   fi
 
   get-args '?owner:get-user/repo:get-repo'
-
-  url="https://github.com/$owner/$repo"
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  url="https://github.com/$owner/$repo/tree/$branch"
 
   if [ -n "$path" ]; then
-    branch="$(git rev-parse --abbrev-ref HEAD)"
-    if "$raw_output"; then
-      quiet_output=false
-      url+="/raw/$branch/$path"
-    else
-      url+="/blob/$branch/$path"
-    fi
+    url+="/$path"
     if [ -n "$line" ]; then
       url+="#L$line"
     fi


### PR DESCRIPTION
branch should be checked even if path is not given
