### PR TITLE
Add message about 2FA auth codes

### DIFF
--- a/lib/git-hub.d/git-hub-setup
+++ b/lib/git-hub.d/git-hub-setup
@@ -91,9 +91,11 @@ for you and put it in the config file.
   fi
   cat <<...
 
-To generate a new token, the commands require your GitHub password.
+To generate a new token, the commands require your GitHub password. If 2FA
+(two-factor authentication) is enabled for your Github account, you will also
+be prompted for a 2FA code.
 
-The password will not be stored after the commands finish running.
+The password and token will not be stored after the commands finish running.
 ...
   export GIT_HUB_PASSWORD="$(
     prompt "Enter your GitHub password (for '$login'): "


### PR DESCRIPTION
Per issue #158, it's not currently clear that accounts protected by
two-factor auth are supported. This adds a note about that support and
fixes #158.