### PR TITLE
configure preferred user.(name|email) for cloning

### DIFF
--- a/lib/git-hub.d/git-hub-other
+++ b/lib/git-hub.d/git-hub-other
@@ -131,16 +131,10 @@ command:clone() {
 
   # configure preferred email/name locally
   local useremail=""
-  read-config-value "github-email"
-  if [ -n "$value" ]; then
-      useremail='--config user.email="'$value'"'
-  fi
+  read-config-value "github-email" && useremail='--config user.email="'$value'"'
 
   local username=""
-  read-config-value "github-name"
-  if [ -n "$value" ]; then
-      username='--config user.name="'$value'"'
-  fi
+  read-config-value "github-name" && username='--config user.name="'$value'"'
 
   cmd="git clone --recursive $url $dir $useremail $username"
 

--- a/lib/git-hub.d/git-hub-other
+++ b/lib/git-hub.d/git-hub-other
@@ -128,7 +128,22 @@ command:clone() {
   owner_repo="$owner/$repo"
 
   url="git@github.com:$owner_repo"
-  cmd="git clone --recursive $url $dir"
+
+  # configure preferred email/name locally
+  local useremail=""
+  read-config-value "github-email"
+  if [ -n "$value" ]; then
+      useremail='--config user.email="'$value'"'
+  fi
+
+  local username=""
+  read-config-value "github-name"
+  if [ -n "$value" ]; then
+      username='--config user.name="'$value'"'
+  fi
+
+  cmd="git clone --recursive $url $dir $useremail $username"
+
   if [ -n "$branch_name" ]; then
     cmd+=" --branch $branch_name"
   fi


### PR DESCRIPTION
At work I have globally configured my name and email address in git.
If checking out github or other repositories, I have to configure my private address manually and tend to forget that.

Does it make sense to configure a name/email and set that locally when cloning?