### PR TITLE
error message when using `--json` and result is empty

### DIFF
--- a/lib/git-hub.d/json-setup.bash
+++ b/lib/git-hub.d/json-setup.bash
@@ -75,6 +75,9 @@ json-dump-object-pairs() {
 pretty-json-list() {
   local num="$(JSON.cache | tail -n1 | cut -d '/' -f2)"
   declare -a keys=("$@")
+  if [[ -z "$num" ]]; then
+      num=-1
+  fi
 
   echo '['
   for (( i = 0; i <= $num; i++)); do


### PR DESCRIPTION
Trying to fetch the list of issues. When the list is empty, I get an error message when using `--json`:

```
$ git hub issues ingydotnet/lw    
Issues for 'ingydotnet/lw' (state=open):
--None--
$ git hub issues ingydotnet/lw --raw
$ git hub issues ingydotnet/lw --json
Issues for 'ingydotnet/lw' (state=open):
[
/paqth/to/git-hub/lib/git-hub.d/json-setup.bash: line 82: ((: i <= : syntax error: operand expected (error token is "<= ")
]
```