### PR TITLE
Output cache dir when debugging with -R

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -250,6 +250,9 @@ api-call() {
     # Use the cache
     [ -e "$command_header_file" ] ||
       error "-R flag not valid. Command not previously run."
+    if "$verbose_output"; then
+      echo "cache dir: $GIT_HUB_CACHE/$command_sha1"$'\n' >&2
+    fi
     rc=0
   else
     local cache_dir="$GIT_HUB_CACHE/$command_sha1"


### PR DESCRIPTION
When there's a problem with the json, it's useful to know in which
file to look immediately. Since `~/.git-hub/cache/out` isn't updated
if the response comes from the cache.

Alternatively/additionally also update `~/.git-hub/cache/out` when using the
cache (which would also make sense since `err` and `head` are also updated, and
then the `out` doesn't belong to the same response anymore)
