### PR TITLE
bug in json-var-list: variables don't get reset

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -773,6 +773,9 @@ report-list-process() {
       for field in "${fields[@]}"; do
         var="${field//\//__}"_"$ii"
         values+=("${!var}")
+        # unset as soon as we don't need it aymore; otherwise it might be
+        # leftover when calling api-call and json-var-list more than once
+        unset -v $var
       done
       local output_line=
       if can "format-entry:$command"; then


### PR DESCRIPTION
report-list-process calls json-var-list several times if there is more than
one page.

The events API returns events which have different keys. Some might have
the key payload/ref, some might not.

If, for example, entry 3 of the first list has payload/ref, and entry 3 of
the second list has not, the variable will still be set from the first list.

https://github.com/perlpunk/git-hub/blob/master/lib/git-hub.d/json-setup.bash#L138
`printf -v "$key" "%s" "$value"`

My first thought is: before the loop which populates the variables,
iterate over the list and over the field names and reset all variables.
But maybe there is an easier way. Declaring these variables locally somehow?

Right now I cannot give an example, becaue I'm seeing this while experimenting
with the events API. I can try to push a simple example in the next days.

