### PR TITLE
completion: allow hyphens in github login when completing repo names

### DIFF
--- a/share/zsh-completion/_git-hub
+++ b/share/zsh-completion/_git-hub
@@ -45,7 +45,7 @@ _git-hub() {
     repo)
         case $line[1] in
         clone|collabs|comment|fork|forks|issue|issue-close|issue-edit|issue-new|issue-resolve|issues|open|pr-diff|pr-fetch|pr-list|pr-merge|repo|repo-delete|repo-edit|repo-get|star|stars|trust|unstar|untrust|unwatch|url|watch|watchers)
-            if [[ $line[2] =~ "^(\w+)/(.*)" ]];
+            if [[ $line[2] =~ "^((\w|-)+)/(.*)" ]];
             then
                 local username="$match[1]"
                 if [[ "$username" != "$__git_hub_lastusername" ]];

--- a/tool/generate-completion.pl
+++ b/tool/generate-completion.pl
@@ -108,7 +108,7 @@ _git-hub() {
     print join '|', @$repo_cmds;
     print <<"...";
 )
-            if [[ \$line[2] =~ "^(\\w+)/(.*)" ]];
+            if [[ \$line[2] =~ "^((\\w|-)+)/(.*)" ]];
             then
                 local username="\$match[1]"
                 if [[ "\$username" != "\$__git_hub_lastusername" ]];


### PR DESCRIPTION
`git hub repo user-name/<TAB>` doesn't work
