### PR TITLE
Prompt to reuse or ignore an existing GIT_HUB_MSG_FILE

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -1339,31 +1339,44 @@ init-msg-file() {
     if [[ $last_line =~ ^#[[:space:]]Command:[[:space:]](.*) ]]; then
       local last_cmd="git hub ${BASH_REMATCH[1]}"
       local date=`date -r $GIT_HUB_MSG_FILE`
-      echo -n "
-$GIT_HUB_MSG_FILE still exists, previous command probably wasn't successful.
-The command was: '$last_cmd'
-Date: $date
-You can reuse or delete the old file.
-(a)bort, (r)euse or (d)elete? "
-      local action
-      read action
+      local prompt="(r)euse, (s)how, (d)elete, (a)bort?"
+      echo "
+Found existing $GIT_HUB_MSG_FILE from:
 
-      case $action in
+  command: '$last_cmd'
+  date:    $date
+"
+      while true
+      do
+        echo -n "$prompt "
+        local action
+        read action
 
-        r)
-          # remove all comment lines
-          sed -i -e '/^#.*$/d' $GIT_HUB_MSG_FILE
-          echo "$body" | sed -e '/^$/d' >> "$GIT_HUB_MSG_FILE"
-        ;;
-        d)
-          rm -f "$GIT_HUB_MSG_FILE"
-          echo "$body" > "$GIT_HUB_MSG_FILE"
-        ;;
-        *)
-          exit 0 # or 1?
-        ;;
+        case $action in
 
-      esac
+          r)
+            # remove all comment lines
+            sed -i -e '/^#.*$/d' $GIT_HUB_MSG_FILE
+            echo "$body" | sed -e '/^$/d' >> "$GIT_HUB_MSG_FILE"
+            break
+          ;;
+          d)
+            rm -f "$GIT_HUB_MSG_FILE"
+            echo "$body" > "$GIT_HUB_MSG_FILE"
+            break
+          ;;
+          s)
+              echo
+              head $GIT_HUB_MSG_FILE | grep -v '^#'
+              echo
+          ;;
+          *)
+            exit 0 # or 1?
+          ;;
+
+        esac
+      done
+
     else
       echo "$body" > "$GIT_HUB_MSG_FILE"
     fi

--- a/lib/git-hub
+++ b/lib/git-hub
@@ -1331,9 +1331,11 @@ prompt-to-run-setup() {
 
 init-msg-file() {
   cleanup_msg_file=1
+  local commandline="$command"
+  [[ -n $command_arguments ]] && commandline="$commandline $command_arguments"
   local body="$1
 #
-# Command: $command $command_arguments"
+# Command: $commandline"
   if [[ -f $GIT_HUB_MSG_FILE ]]; then
     local last_line=`tail -1 $GIT_HUB_MSG_FILE`
     if [[ $last_line =~ ^#[[:space:]]Command:[[:space:]](.*) ]]; then

--- a/lib/git-hub
+++ b/lib/git-hub
@@ -1340,7 +1340,13 @@ init-msg-file() {
     local last_line=`tail -1 $GIT_HUB_MSG_FILE`
     if [[ $last_line =~ ^#[[:space:]]Command:[[:space:]](.*) ]]; then
       local last_cmd="git hub ${BASH_REMATCH[1]}"
-      local date=`date -r $GIT_HUB_MSG_FILE`
+      local date
+      if osx; then
+        local epoch=`stat -f "%m" $GIT_HUB_MSG_FILE`
+        date=`date -r $epoch`
+      else
+        date=`date -r $GIT_HUB_MSG_FILE`
+      fi
       local prompt="(r)euse, (s)how, (d)elete, (a)bort?"
       echo "
 Found existing $GIT_HUB_MSG_FILE from:

--- a/lib/git-hub
+++ b/lib/git-hub
@@ -102,6 +102,7 @@ run-command() {
   get-opts "$@"
   assert-env
 
+  local cleanup_msg_file
   callable-or-source "$command" ||
     error "unknown 'git hub' command '$command'"
   "command:$command" "$@"
@@ -114,6 +115,10 @@ run-command() {
       if [[ $msg_ok != 0 ]]; then
         say "${msg_ok:-"'git hub $command' command successful"}"
       fi
+    fi
+    # successful, delete the tmp file
+    if [[ -n "$cleanup_msg_file" ]]; then
+      rm -f $GIT_HUB_MSG_FILE
     fi
   else
     local status_msg="msg_$status_code"
@@ -1323,16 +1328,67 @@ prompt-to-run-setup() {
 #------------------------------------------------------------------------------
 # Reusable helper functions:
 #------------------------------------------------------------------------------
-editor-title-body() {
-  rm -f "$GIT_HUB_MSG_FILE"
 
-  echo "$1" > "$GIT_HUB_MSG_FILE"
+init-msg-file() {
+  cleanup_msg_file=1
+  local body="$1
+#
+# Command: $command $command_arguments"
+  if [[ -f $GIT_HUB_MSG_FILE ]]; then
+    local last_line=`tail -1 $GIT_HUB_MSG_FILE`
+    if [[ $last_line =~ ^#[[:space:]]Command:[[:space:]](.*) ]]; then
+      local last_cmd="git hub ${BASH_REMATCH[1]}"
+      local date=`date -r $GIT_HUB_MSG_FILE`
+      echo -n "
+$GIT_HUB_MSG_FILE still exists, previous command probably wasn't successful.
+The command was: '$last_cmd'
+Date: $date
+You can reuse or delete the old file.
+(a)bort, (r)euse or (d)elete? "
+      local action
+      read action
+
+      case $action in
+
+        r)
+          # remove all comment lines
+          sed -i -e '/^#.*$/d' $GIT_HUB_MSG_FILE
+          echo "$body" | sed -e '/^$/d' >> "$GIT_HUB_MSG_FILE"
+        ;;
+        d)
+          rm -f "$GIT_HUB_MSG_FILE"
+          echo "$body" > "$GIT_HUB_MSG_FILE"
+        ;;
+        *)
+          exit 0 # or 1?
+        ;;
+
+      esac
+    else
+      echo "$body" > "$GIT_HUB_MSG_FILE"
+    fi
+  else
+    echo "$body" > "$GIT_HUB_MSG_FILE"
+  fi
+
+}
+
+delete-empty-msg-file() {
+  local content=`grep -v '^#' $GIT_HUB_MSG_FILE | grep -v '^$'`
+  if [[ -z "$content" ]]; then
+    rm $GIT_HUB_MSG_FILE
+  fi
+}
+
+editor-title-body() {
+  init-msg-file "$1"
 
   $GIT_HUB_EDITOR "$GIT_HUB_MSG_FILE"
   local line
   body=''
   title="$(head -n1 "$GIT_HUB_MSG_FILE")"
   if [[ ! $title =~ [^[:space:]] || $title =~ ^\# ]]; then
+    delete-empty-msg-file
     abort "no title provided"
   fi
   line="$(head -n2 "$GIT_HUB_MSG_FILE" | tail -n1)"
@@ -1351,9 +1407,7 @@ editor-title-body() {
 }
 
 editor-comment() {
-  rm -f "$GIT_HUB_MSG_FILE"
-
-  echo "$1" > "$GIT_HUB_MSG_FILE"
+  init-msg-file "$1"
 
   $GIT_HUB_EDITOR "$GIT_HUB_MSG_FILE"
   local line
@@ -1364,15 +1418,14 @@ editor-comment() {
     [[ $line =~ ^\# ]] && break
     body+="$line"$'\n'
   done < "$GIT_HUB_MSG_FILE"
+  delete-empty-msg-file
   IFS="$ifs"
 }
 
 editor-comment-state() {
-  rm -f "$GIT_HUB_MSG_FILE"
+  init-msg-file "$1"
 
   comment= title= state= assignee= milestone=
-
-  echo "$1" > "$GIT_HUB_MSG_FILE"
 
   $GIT_HUB_EDITOR "$GIT_HUB_MSG_FILE"
   local line started=false
@@ -1402,6 +1455,7 @@ editor-comment-state() {
   IFS="$ifs"
 
   if [[ ! $title =~ [^[:space:]] ]]; then
+    delete-empty-msg-file
     abort "no title provided."
   fi
 }


### PR DESCRIPTION
This needs a bit more work.

See issue #28

After a successful command, delete GIT_HUB_MSG_FILE.
When starting editor and file exists, prompt for reusing, deleting
or aborting.

Still todo:

- [x] Only delete the file after commands that actually use
the editor, so a non-editor-command wouldn't destroy an old file.
- [x] Delete when nothing was entered.
- [x] Show the age of the old file when prompting.
- [x] If reusing, replace the meta information with the one from the new command.