### PR TITLE
fix --json output for cases where we have a key_prefix

### DIFF
--- a/lib/git-hub.d/json-setup.bash
+++ b/lib/git-hub.d/json-setup.bash
@@ -73,7 +73,12 @@ json-dump-object-pairs() {
 }
 
 pretty-json-list() {
-  local num="$(JSON.cache | tail -n1 | cut -d '/' -f2)"
+  local num
+  if [[ -n "$key_prefix" ]]; then
+    num="$(JSON.object "$key_prefix" - | tail -n1 | cut -d '/' -f2)"
+  else
+    num="$(JSON.cache | tail -n1 | cut -d '/' -f2)"
+  fi
   declare -a keys=("$@")
   if [[ -z $num ]]; then
       num=-1
@@ -85,7 +90,7 @@ pretty-json-list() {
     for (( j = 0; j < ${#keys[@]}; j++)); do
       local key="${keys[$j]}"
       local key="${key//__/\/}"
-      local value="$(JSON.get "/$i/$key" - || true)"
+      local value="$(JSON.get "$key_prefix/$i/$key" - || true)"
       if [[ -n $value ]]; then
         printf "    \"%s\": %s" "$key" "$value"
         [[ $(($j+1)) -lt ${#keys[@]} ]] && printf ','


### PR DESCRIPTION
Commands like pr-queue which have a key prefix would result in
empty json or an error:

```
% git hub pr-queue --json
[
  {
  }
]

% git hub pr-queue --json -c 3
[
/.../git-hub/lib/git-hub.d/json-setup.bash: line 85: ((: i <= incomplete_results   false: syntax error in expression (error token is "false")
]
```

Also, -c is ignored in the curl request when used with --json; you always
get the full list. Is this intended?
