### PR TITLE
Shell completion for user/repo via search commands

### DIFF
--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -843,7 +843,47 @@ The C<git hub> command supports C<< <TAB> >>-based command completion. If you
 don't use the C<.rc> script (see Installation, above), you'll need to enable
 this manually to use it.
 
-=head2 In Bash
+Completion is supported for subcommands, options and config keys.
+
+      git hub <TAB>
+      git hub pr-list --<TAB>
+      git hub config <TAB>
+      git hub help <TAB>
+
+Additionally, user/repo names can be completed, but note that there might be
+some cases where this will not offer all possible names.
+
+The reason is the search is restricted to 100 items, and a search cannot be
+anchored to the start of a string, so an API call might return 100 results,
+but you will only see those starting with the prefix you typed.
+
+=head2 Completing repository names
+
+      git hub repo <TAB>          shortcut for your-login/<TAB>
+      git hub repo @<TAB>         shortcut for your-login/<TAB>
+      git hub repo foo<TAB>       shortcut for your-login/foo<TAB>
+      git hub repo user/<TAB>     complete repos of 'user'
+      git hub repo user/foo<TAB>  complete repos of 'user' starting with foo
+
+=head2 Completing user names as part of the full repository name
+
+For completing usernames, you have to type a C<@> and at least two characters.
+
+C<< git hub repo @in<TAB> >>
+
+The C<@> will automatically go away if there is only one matching user, or if
+you add a C</> after it.
+
+      git hub repo @ingyd<TAB>         -> git hub repo ingydotnet/
+      git hub repo @ingydotnet/<TAB>   -> git hub repo ingydotnet/
+
+=head2 Completing user names for commands like follow, user, trust
+
+This is not supported yet.
+
+=head2 Enabling completion
+
+=head3 In Bash
 
 If your Bash setup does not already provide command completion for Git, you'll
 need to enable that first:
@@ -879,13 +919,17 @@ not), you can turn on C<git-hub> completion with a command like this:
 
     source /path/to/git-hub/share/completion.bash
 
-=head2 In zsh
+=head3 In zsh
 
 In the Z shell (zsh), you can manually enable C<git-hub> completion by
 adding the following line to your C<~/.zshrc>, B<before> the C<compinit>
 function is called:
 
     fpath=('/path/to/git-hub/share/zsh-completion' $fpath)
+
+You might want to enable caching (the cache is invalidated after 20 minutes):
+
+      zstyle ':completion:*' use-cache on
 
 =head1 Plugins
 

--- a/doc/git-hub.swim
+++ b/doc/git-hub.swim
@@ -674,7 +674,47 @@ The `git hub` command supports `<TAB>`-based command completion. If you don't
 use the `.rc` script (see Installation, above), you'll need to enable this
 manually to use it.
 
-== In Bash
+Completion is supported for subcommands, options and config keys.
+
+    git hub <TAB>
+    git hub pr-list --<TAB>
+    git hub config <TAB>
+    git hub help <TAB>
+
+Additionally, user/repo names can be completed, but note that there might
+be some cases where this will not offer all possible names.
+
+The reason is the search is restricted to 100 items, and a search cannot be
+anchored to the start of a string, so an API call might return 100 results,
+but you will only see those starting with the prefix you typed.
+
+== Completing repository names
+
+    git hub repo <TAB>          shortcut for your-login/<TAB>
+    git hub repo @<TAB>         shortcut for your-login/<TAB>
+    git hub repo foo<TAB>       shortcut for your-login/foo<TAB>
+    git hub repo user/<TAB>     complete repos of 'user'
+    git hub repo user/foo<TAB>  complete repos of 'user' starting with foo
+
+== Completing user names as part of the full repository name
+
+For completing usernames, you have to type a `@` and at least two characters.
+
+`git hub repo @in<TAB>`
+
+The `@` will automatically go away if there is only one matching user, or if
+you add a `/` after it.
+
+    git hub repo @ingyd<TAB>         -> git hub repo ingydotnet/
+    git hub repo @ingydotnet/<TAB>   -> git hub repo ingydotnet/
+
+== Completing user names for commands like follow, user, trust
+
+This is not supported yet.
+
+== Enabling completion
+
+=== In Bash
 
 If your Bash setup does not already provide command completion for Git, you'll
 need to enable that first:
@@ -701,13 +741,17 @@ not), you can turn on `git-hub` completion with a command like this:
 
   source /path/to/git-hub/share/completion.bash
 
-== In zsh
+=== In zsh
 
 In the Z shell (zsh), you can manually enable `git-hub` completion by adding
 the following line to your `~/.zshrc`, *before* the `compinit` function is
 called:
 
   fpath=('/path/to/git-hub/share/zsh-completion' $fpath)
+
+You might want to enable caching (the cache is invalidated after 20 minutes):
+
+    zstyle ':completion:*' use-cache on
 
 = Plugins
 

--- a/man/man1/git-hub.1
+++ b/man/man1/git-hub.1
@@ -762,8 +762,48 @@ If you used \f(CW\*(C`make install\*(C'\fR method, then run this again (after \f
 .SH "Command Completion"
 .IX Header "Command Completion"
 The \f(CW\*(C`git hub\*(C'\fR command supports \f(CW\*(C`<TAB>\*(C'\fR\-based command completion. If you don't use the \f(CW\*(C`.rc\*(C'\fR script (see Installation, above), you'll need to enable this manually to use it.
-.SS "In Bash"
+.PP
+Completion is supported for subcommands, options and config keys.
+.PP
+.Vb 4
+\&      git hub <TAB>
+\&      git hub pr\-list \-\-<TAB>
+\&      git hub config <TAB>
+\&      git hub help <TAB>
+.Ve
+.PP
+Additionally, user/repo names can be completed, but note that there might be some cases where this will not offer all possible names.
+.PP
+The reason is the search is restricted to 100 items, and a search cannot be anchored to the start of a string, so an \s-1API\s0 call might return 100 results, but you will only see those starting with the prefix you typed.
+.SS "Completing repository names"
+.IX Subsection "Completing repository names"
+.Vb 5
+\&      git hub repo <TAB>          shortcut for your\-login/<TAB>
+\&      git hub repo @<TAB>         shortcut for your\-login/<TAB>
+\&      git hub repo foo<TAB>       shortcut for your\-login/foo<TAB>
+\&      git hub repo user/<TAB>     complete repos of \*(Aquser\*(Aq
+\&      git hub repo user/foo<TAB>  complete repos of \*(Aquser\*(Aq starting with foo
+.Ve
+.SS "Completing user names as part of the full repository name"
+.IX Subsection "Completing user names as part of the full repository name"
+For completing usernames, you have to type a \f(CW\*(C`@\*(C'\fR and at least two characters.
+.PP
+\&\f(CW\*(C`git hub repo @in<TAB>\*(C'\fR
+.PP
+The \f(CW\*(C`@\*(C'\fR will automatically go away if there is only one matching user, or if you add a \f(CW\*(C`/\*(C'\fR after it.
+.PP
+.Vb 2
+\&      git hub repo @ingyd<TAB>         \-> git hub repo ingydotnet/
+\&      git hub repo @ingydotnet/<TAB>   \-> git hub repo ingydotnet/
+.Ve
+.SS "Completing user names for commands like follow, user, trust"
+.IX Subsection "Completing user names for commands like follow, user, trust"
+This is not supported yet.
+.SS "Enabling completion"
+.IX Subsection "Enabling completion"
+\fIIn Bash\fR
 .IX Subsection "In Bash"
+.PP
 If your Bash setup does not already provide command completion for Git, you'll need to enable that first:
 .PP
 .Vb 1
@@ -795,12 +835,20 @@ Once Git completion is enabled (whether you needed to do that manually or not), 
 .Vb 1
 \&    source /path/to/git\-hub/share/completion.bash
 .Ve
-.SS "In zsh"
+.PP
+\fIIn zsh\fR
 .IX Subsection "In zsh"
+.PP
 In the Z shell (zsh), you can manually enable \f(CW\*(C`git\-hub\*(C'\fR completion by adding the following line to your \f(CW\*(C`~/.zshrc\*(C'\fR, \fBbefore\fR the \f(CW\*(C`compinit\*(C'\fR function is called:
 .PP
 .Vb 1
 \&    fpath=(\*(Aq/path/to/git\-hub/share/zsh\-completion\*(Aq $fpath)
+.Ve
+.PP
+You might want to enable caching (the cache is invalidated after 20 minutes):
+.PP
+.Vb 1
+\&      zstyle \*(Aq:completion:*\*(Aq use\-cache on
 .Ve
 .SH "Plugins"
 .IX Header "Plugins"

--- a/share/completion.bash
+++ b/share/completion.bash
@@ -5,6 +5,7 @@
 _git_hub() {
     local _opts=" -h --help --remote= --branch= --sha= --org= --method= --title= --msg= -c= --count= -a --all -q --quiet -v --verbose -r --raw -j --json -A --use-auth -C --no-cache --token= -d --dryrun -T -O -H -J -R -x"
     local subcommands="cache-clear clone collabs comment config config-keys config-list config-unset follow followers following follows fork forks gist gist-clone gist-delete gist-edit gist-fork gist-get gist-init gist-new gist-star gist-unstar gists git-hub-travis help info irc-enable irc-enable irc-url issue issue-close issue-edit issue-new issue-resolve issues keys keys-add member-add member-get member-remove members notify-list open org org-edit org-get org-members org-repos orgs pr-created pr-diff pr-fetch pr-involves pr-list pr-merge pr-new pr-queue repo repo-delete repo-edit repo-get repo-init repo-new repos scope-add scope-remove scopes search-issues search-repo search-user setup star starred stars team team-delete team-members team-new team-repo-add team-repos teams token-delete token-get token-new tokens trust unfollow unstar untrust unwatch upgrade url user user-edit user-get version watch watchers watching"
+    local repocommands="clone collabs comment fork forks issue issue-close issue-edit issue-new issue-resolve issues open pr-diff pr-fetch pr-list pr-merge repo repo-delete repo-edit repo-get star stars trust unstar untrust unwatch url watch watchers"
     local subcommand="$(__git_find_on_cmdline "$subcommands")"
 
     if [ -z "$subcommand" ]; then
@@ -34,18 +35,126 @@ _git_hub() {
             __gitcomp "$_opts"
             return
         ;;
-
-        *)
-            if [[ $subcommand == help ]]; then
-                __gitcomp "$subcommands"
-            elif [[ $subcommand == "config" || $subcommand == "config-unset" ]]; then
-                local config_keys
-                config_keys=`git hub config-keys`
-                __gitcomp "$config_keys"
-            fi
-        ;;
-
         esac
 
+        if [[ $subcommand == help ]]; then
+            __gitcomp "$subcommands"
+            return
+        elif [[ $subcommand == "config" || $subcommand == "config-unset" ]]; then
+            local config_keys
+            config_keys=`git hub config-keys`
+            __gitcomp "$config_keys"
+            return
+        fi
+
+        local repocommand="$(__git_find_on_cmdline "$repocommands")"
+        if [ -n "$repocommand" ]; then
+
+            local repo_to_complete="$cur"
+            if [[ "$repo_to_complete" == "" || "$repo_to_complete" == "@" ]]; then
+                local login=`git hub config login`
+                COMPREPLY=("$login/")
+                return
+            elif [[ "$repo_to_complete" =~ ^@/ || "$repo_to_complete" =~ ^/ ]]; then
+                local login=`git hub config login`
+                repo_to_complete="${repo_to_complete/\@}"
+                repo_to_complete="$login""$repo_to_complete"
+            elif [[ "$repo_to_complete" =~ ^@.+/ ]]; then
+                repo_to_complete="${repo_to_complete/\@}"
+            elif [[ "$repo_to_complete" =~ ^([a-zA-Z0-9_-]+)$ ]]; then
+                local login=`git hub config login`
+                repo_to_complete="$login/$repo_to_complete"
+            fi
+
+            # note: username completion works only for lowercase at the
+            # moment. usernames with uppercase letters will be lowercased
+            if [[ "$repo_to_complete" =~ ^@([a-z0-9_][a-z0-9_-]+) ]];
+            then
+                # git hub repo @foo<TAB>
+                local username="${BASH_REMATCH[1]}"
+                # first, check the cache
+                local cached
+                __git_hub_try_cache "user" "$username"
+                local users=("${cached[@]}")
+                if [[ -z "$cached" ]]; then
+                    # nothing in cache
+                    # echo $'\n'"Completing usernames..."
+                    users=( $(git hub search-user "$username in:login" --raw --count 100 | tr '[:upper:]' '[:lower:]' | sed -e 's/^/@/' ) )
+                fi
+                local comp="${users[@]}"
+                COMPREPLY=( $( compgen -W "$comp" -- "@$username" ) )
+                local count=${#COMPREPLY[@]}
+                if [[ $count -eq 1 ]]; then
+                    local user="${COMPREPLY[0]}"
+                    user="${user/\@/}"
+                    COMPREPLY=("$user/")
+                fi
+                if [[ -z "$cached" ]]; then
+                    __git_hub_save_user_cache "$username"
+                fi
+
+            else
+                local username reponame
+                if [[ "$repo_to_complete" =~ ^([a-zA-Z0-9_-]+)/(.*) ]];
+                then
+                    # git hub repo foobar/<TAB>
+                    username="${BASH_REMATCH[1]}"
+                    reponame="${BASH_REMATCH[2]}"
+                else
+                    # git hub repo foobar<TAB>
+                    username=`git hub config login`
+                    reponame="$repo_to_complete"
+                fi
+
+                # first, check the cache
+                local cached
+                __git_hub_try_cache "repo" "$username/$reponame"
+                local reponames=("${cached[@]}")
+                if [[ -z "$cached" ]]; then
+                    # nothing in cache
+                    # echo $'\n'"Completing reponames..."
+                    reponames=( $( git hub search-repo "$reponame user:$username in:name fork:true" --raw --count 100 ) )
+                    __git_hub_save_repo_cache "$username/$reponame"
+                fi
+                local comp="${reponames[@]}"
+                COMPREPLY=( $( compgen -W "$comp" -- "$username/$reponame" ) )
+
+            fi
+
+        fi
+
+    fi
+}
+
+__git_hub_save_repo_cache() {
+    __git_hub_last_repo="$1"
+    __git_hub_last_repo_result=("${reponames[@]}")
+}
+
+__git_hub_save_user_cache() {
+    __git_hub_last_user="$1"
+    __git_hub_last_user_result=("${users[@]}")
+}
+
+__git_hub_try_cache() {
+    local cachetype="$1"
+    local name="$2"
+    local last="__git_hub_last_$cachetype"
+    local last_result="__git_hub_last_${cachetype}_result"
+    # if we got 100 results that means that there were probably more, so the
+    # result is incomplete. We only return this cached result if the
+    # key equals the cache key from last time.
+    local key="${!last}"
+    local result
+    if [[ $cachetype == user ]]; then
+        result=("${__git_hub_last_user_result[@]}")
+    elif [[ $cachetype == repo ]]; then
+        result=("${__git_hub_last_repo_result[@]}")
+    fi
+    if [[ "$key" == "$name" \
+        || ( "${name:0:${#key}}" == "$key" \
+        && ${#result[@]} -lt 100 \
+        ) ]]; then
+        cached=("${result[@]}")
     fi
 }

--- a/share/zsh-completion/_git-hub
+++ b/share/zsh-completion/_git-hub
@@ -12,6 +12,12 @@ _git-hub() {
     typeset -A opt_args
     local curcontext="$curcontext" state line context
 
+    local update_policy
+    zstyle -s ":completion:$curcontext:" cache-policy update_policy
+    if [[ -z "$update_policy" ]]; then
+        zstyle ":completion:$curcontext:" cache-policy _git_hub_caching_policy
+    fi
+
     _arguments -s \
         '1: :->subcmd' \
         '2: :->repo' \
@@ -49,19 +55,76 @@ _git-hub() {
     repo)
         case $line[1] in
         clone|collabs|comment|fork|forks|issue|issue-close|issue-edit|issue-new|issue-resolve|issues|open|pr-diff|pr-fetch|pr-list|pr-merge|repo|repo-delete|repo-edit|repo-get|star|stars|trust|unstar|untrust|unwatch|url|watch|watchers)
-            if [[ $line[2] =~ "^((\w|-)+)/(.*)" ]];
+            [[ "$line[2]" =~ ^- ]] && return;
+            local repo_to_complete="$line[2]"
+            if [[ "$repo_to_complete" =~ "^@/?$" || \
+                "$repo_to_complete" =~ "^@/(.*)" || \
+                "$repo_to_complete" =~ "^/?([a-z0-9_-]*)$" ]];
             then
+                local login=`git hub config login`
+                compadd -U -S '' "$login/$match[1]"
+                return
+            elif [[ "$repo_to_complete" =~ "^@.+/" ]]; then
+                repo_to_complete="${repo_to_complete/\@}"
+                compadd -U -S '' "$repo_to_complete"
+                return
+            fi
+
+            if [[ "$repo_to_complete" =~ "^@([a-z0-9_][a-z0-9_-]*)$" ]];
+            then
+                local users
                 local username="$match[1]"
-                if [[ "$username" != "$__git_hub_lastusername" ]];
-                then
-                    __git_hub_lastusername=$username
-                    IFS=$'\n' set -A  __git_hub_reponames `git hub repos $username --raw`
+
+                if [[ "$#username" -lt 2 ]]; then
+                    compadd -x "Users (type at least two characters)"
+                    return
                 fi
-                compadd -X "Repos:" $__git_hub_reponames
+
+                local _git_hub_cached_users
+                local cache_key="git-hub-search-user-$username"
+                if _cache_invalid $cache_key || ! _retrieve_cache $cache_key ; then
+                    users=( $( git hub search-user "$username in:login" --raw --count 100 | tr '[:upper:]' '[:lower:]' | sed -e 's/^/@/' ) )
+                    _git_hub_cached_users=("${users[@]}")
+                    _store_cache $cache_key _git_hub_cached_users
+                else
+                    users=("${_git_hub_cached_users[@]}")
+                fi
+
+                if [[ ${#users[@]} -eq 1 ]]; then
+                    local user="$users[1]"
+                    user="${user/\@/}"
+                    compadd -S / -U -X "Users:" "$user"
+                else
+                    compadd -U -X "Users:" $users
+                fi
+
             else
-                _arguments "2:Repos:()"
+                local username reponame
+                if [[ "$repo_to_complete" =~ "^([a-z0-9_][a-z0-9_-]+)/([a-zA-Z0-9_.-]*)" ]];
+                then
+                    local username="$match[1]"
+                    local reponame="$match[2]"
+                else
+                    # git hub repo foobar<TAB>
+                    username=`git hub config login`
+                    reponame="$repo_to_complete"
+                fi
+                local reponames
+
+                local _git_hub_cached_repos
+                local cache_key="git-hub-search-repo-$username/repo-$reponame"
+                if _cache_invalid $cache_key || ! _retrieve_cache $cache_key ; then
+                    IFS=$'\n' set -A reponames `git hub search-repo "$reponame user:$username in:name fork:true" --raw --count 100`
+                    _git_hub_cached_repos=("${reponames[@]}")
+                    _store_cache $cache_key _git_hub_cached_repos
+                else
+                    reponames=("${_git_hub_cached_repos[@]}")
+                fi
+
+                compadd -X "Repos:" $reponames
             fi
         ;;
+
         config|config-unset)
             local config_keys
             IFS=$'\n' set -A config_keys `git hub config-keys`
@@ -82,4 +145,12 @@ _git-hub-complete-remote() {
     compadd -X "remote:" $dynamic_comp
 }
 
+
+_git_hub_caching_policy() {
+    local -a oldp
+    # older than 20 minutes
+    oldp=( "$1"(mm+20) )
+    (( $#oldp )) && return 0
+    return 1
+}
 

--- a/tool/generate-completion.pl
+++ b/tool/generate-completion.pl
@@ -127,6 +127,12 @@ _git-hub() {
     typeset -A opt_args
     local curcontext="$curcontext" state line context
 
+    local update_policy
+    zstyle -s ":completion:$curcontext:" cache-policy update_policy
+    if [[ -z "$update_policy" ]]; then
+        zstyle ":completion:$curcontext:" cache-policy _git_hub_caching_policy
+    fi
+
     _arguments -s \
         '1: :->subcmd' \
         '2: :->repo' \
@@ -148,19 +154,76 @@ _git-hub() {
     print join '|', @$repo_cmds;
     print <<"...";
 )
-            if [[ \$line[2] =~ "^((\\w|-)+)/(.*)" ]];
+            [[ "\$line[2]" =~ ^- ]] && return;
+            local repo_to_complete="\$line[2]"
+            if [[ "\$repo_to_complete" =~ "^\@/?\$" || \\
+                "\$repo_to_complete" =~ "^\@/(.*)" || \\
+                "\$repo_to_complete" =~ "^/?([a-z0-9_-]*)\$" ]];
             then
+                local login=`git hub config login`
+                compadd -U -S '' "\$login/\$match[1]"
+                return
+            elif [[ "\$repo_to_complete" =~ "^\@.+/" ]]; then
+                repo_to_complete="\${repo_to_complete/\\\@}"
+                compadd -U -S '' "\$repo_to_complete"
+                return
+            fi
+
+            if [[ "\$repo_to_complete" =~ "^\@([a-z0-9_][a-z0-9_-]*)\$" ]];
+            then
+                local users
                 local username="\$match[1]"
-                if [[ "\$username" != "\$__git_hub_lastusername" ]];
-                then
-                    __git_hub_lastusername=\$username
-                    IFS=\$'\\n' set -A  __git_hub_reponames `git hub repos \$username --raw`
+
+                if [[ "\$#username" -lt 2 ]]; then
+                    compadd -x "Users (type at least two characters)"
+                    return
                 fi
-                compadd -X "Repos:" \$__git_hub_reponames
+
+                local _git_hub_cached_users
+                local cache_key="git-hub-search-user-\$username"
+                if _cache_invalid \$cache_key || ! _retrieve_cache \$cache_key ; then
+                    users=( \$( git hub search-user "\$username in:login" --raw --count 100 | tr '[:upper:]' '[:lower:]' | sed -e 's/^/\@/' ) )
+                    _git_hub_cached_users=("\${users[\@]}")
+                    _store_cache \$cache_key _git_hub_cached_users
+                else
+                    users=("\${_git_hub_cached_users[\@]}")
+                fi
+
+                if [[ \${#users[\@]} -eq 1 ]]; then
+                    local user="\$users[1]"
+                    user="\${user/\\\@/}"
+                    compadd -S / -U -X "Users:" "\$user"
+                else
+                    compadd -U -X "Users:" \$users
+                fi
+
             else
-                _arguments "2:Repos:()"
+                local username reponame
+                if [[ "\$repo_to_complete" =~ "^([a-z0-9_][a-z0-9_-]+)/([a-zA-Z0-9_.-]*)" ]];
+                then
+                    local username="\$match[1]"
+                    local reponame="\$match[2]"
+                else
+                    # git hub repo foobar<TAB>
+                    username=`git hub config login`
+                    reponame="\$repo_to_complete"
+                fi
+                local reponames
+
+                local _git_hub_cached_repos
+                local cache_key="git-hub-search-repo-\$username/repo-\$reponame"
+                if _cache_invalid \$cache_key || ! _retrieve_cache \$cache_key ; then
+                    IFS=\$'\\n' set -A reponames `git hub search-repo "\$reponame user:\$username in:name fork:true" --raw --count 100`
+                    _git_hub_cached_repos=("\${reponames[\@]}")
+                    _store_cache \$cache_key _git_hub_cached_repos
+                else
+                    reponames=("\${_git_hub_cached_repos[\@]}")
+                fi
+
+                compadd -X "Repos:" \$reponames
             fi
         ;;
+
         config|config-unset)
             local config_keys
             IFS=\$'\\n' set -A config_keys `git hub config-keys`
@@ -176,6 +239,14 @@ _git-hub() {
 }
 
 $function_list
+_git_hub_caching_policy() {
+    local -a oldp
+    # older than 20 minutes
+    oldp=( "\$1"(mm+20) )
+    (( \$#oldp )) && return 0
+    return 1
+}
+
 ...
 }
 
@@ -221,6 +292,7 @@ sub generate_bash {
 _git_hub() {
     local _opts="$options_string"
     local subcommands="@$list"
+    local repocommands="@$repo_cmds"
     local subcommand="\$(__git_find_on_cmdline "\$subcommands")"
 
     if [ -z "\$subcommand" ]; then
@@ -246,19 +318,127 @@ $function_list
             __gitcomp "\$_opts"
             return
         ;;
-
-        *)
-            if [[ \$subcommand == help ]]; then
-                __gitcomp "\$subcommands"
-            elif [[ \$subcommand == "config" || \$subcommand == "config-unset" ]]; then
-                local config_keys
-                config_keys=`git hub config-keys`
-                __gitcomp "\$config_keys"
-            fi
-        ;;
-
         esac
 
+        if [[ \$subcommand == help ]]; then
+            __gitcomp "\$subcommands"
+            return
+        elif [[ \$subcommand == "config" || \$subcommand == "config-unset" ]]; then
+            local config_keys
+            config_keys=`git hub config-keys`
+            __gitcomp "\$config_keys"
+            return
+        fi
+
+        local repocommand="\$(__git_find_on_cmdline "\$repocommands")"
+        if [ -n "\$repocommand" ]; then
+
+            local repo_to_complete="\$cur"
+            if [[ "\$repo_to_complete" == "" || "\$repo_to_complete" == "\@" ]]; then
+                local login=`git hub config login`
+                COMPREPLY=("\$login/")
+                return
+            elif [[ "\$repo_to_complete" =~ ^\@/ || "\$repo_to_complete" =~ ^/ ]]; then
+                local login=`git hub config login`
+                repo_to_complete="\${repo_to_complete/\\\@}"
+                repo_to_complete="\$login""\$repo_to_complete"
+            elif [[ "\$repo_to_complete" =~ ^\@.+/ ]]; then
+                repo_to_complete="\${repo_to_complete/\\\@}"
+            elif [[ "\$repo_to_complete" =~ ^([a-zA-Z0-9_-]+)\$ ]]; then
+                local login=`git hub config login`
+                repo_to_complete="\$login/\$repo_to_complete"
+            fi
+
+            # note: username completion works only for lowercase at the
+            # moment. usernames with uppercase letters will be lowercased
+            if [[ "\$repo_to_complete" =~ ^@([a-z0-9_][a-z0-9_-]+) ]];
+            then
+                # git hub repo \@foo<TAB>
+                local username="\${BASH_REMATCH[1]}"
+                # first, check the cache
+                local cached
+                __git_hub_try_cache "user" "\$username"
+                local users=("\${cached[\@]}")
+                if [[ -z "\$cached" ]]; then
+                    # nothing in cache
+                    # echo \$'\\n'"Completing usernames..."
+                    users=( \$(git hub search-user "\$username in:login" --raw --count 100 | tr '[:upper:]' '[:lower:]' | sed -e 's/^/\@/' ) )
+                fi
+                local comp="\${users[\@]}"
+                COMPREPLY=( \$( compgen -W "\$comp" -- "\@\$username" ) )
+                local count=\${#COMPREPLY[\@]}
+                if [[ \$count -eq 1 ]]; then
+                    local user="\${COMPREPLY[0]}"
+                    user="\${user/\\\@/}"
+                    COMPREPLY=("\$user/")
+                fi
+                if [[ -z "\$cached" ]]; then
+                    __git_hub_save_user_cache "\$username"
+                fi
+
+            else
+                local username reponame
+                if [[ "\$repo_to_complete" =~ ^([a-zA-Z0-9_-]+)/(.*) ]];
+                then
+                    # git hub repo foobar/<TAB>
+                    username="\${BASH_REMATCH[1]}"
+                    reponame="\${BASH_REMATCH[2]}"
+                else
+                    # git hub repo foobar<TAB>
+                    username=`git hub config login`
+                    reponame="\$repo_to_complete"
+                fi
+
+                # first, check the cache
+                local cached
+                __git_hub_try_cache "repo" "\$username/\$reponame"
+                local reponames=("\${cached[\@]}")
+                if [[ -z "\$cached" ]]; then
+                    # nothing in cache
+                    # echo \$'\\n'"Completing reponames..."
+                    reponames=( \$( git hub search-repo "\$reponame user:\$username in:name fork:true" --raw --count 100 ) )
+                    __git_hub_save_repo_cache "\$username/\$reponame"
+                fi
+                local comp="\${reponames[\@]}"
+                COMPREPLY=( \$( compgen -W "\$comp" -- "\$username/\$reponame" ) )
+
+            fi
+
+        fi
+
+    fi
+}
+
+__git_hub_save_repo_cache() {
+    __git_hub_last_repo="\$1"
+    __git_hub_last_repo_result=("\${reponames[@]}")
+}
+
+__git_hub_save_user_cache() {
+    __git_hub_last_user="\$1"
+    __git_hub_last_user_result=("\${users[@]}")
+}
+
+__git_hub_try_cache() {
+    local cachetype="\$1"
+    local name="\$2"
+    local last="__git_hub_last_\$cachetype"
+    local last_result="__git_hub_last_\${cachetype}_result"
+    # if we got 100 results that means that there were probably more, so the
+    # result is incomplete. We only return this cached result if the
+    # key equals the cache key from last time.
+    local key="\${!last}"
+    local result
+    if [[ \$cachetype == user ]]; then
+        result=("\${__git_hub_last_user_result[@]}")
+    elif [[ \$cachetype == repo ]]; then
+        result=("\${__git_hub_last_repo_result[@]}")
+    fi
+    if [[ "\$key" == "\$name" \\
+        || ( "\${name:0:\${#key}}" == "\$key" \\
+        && \${#result[@]} -lt 100 \\
+        ) ]]; then
+        cached=("\${result[@]}")
     fi
 }
 ...


### PR DESCRIPTION
As we now have the search-(user|repo) commands, the completion for user and
repository names is easier. No need to fetch the complete list of
repositories for a user.

A search will only get 100 items, so if there are more results, the user
has to type more characters to get the results they are looking for.
But in most cases this should be enough.

For usernames, you have to type at least two characters, because github
won't make a search for an empty string or only one character.

`git hub repo in<TAB>`

`git hub repo ingydotnet/<TAB>`

I had to add a caching strategy, though, because in bash, when you type
`<TAB><TAB>`, the completion script is actually executed twice, but will
do the actual completion only after the second TAB.

Please test.
