### PR TITLE
The field `watchers` in repo output should be changed to `stargazers_count`

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -953,7 +953,7 @@ report-value() {
 }
 
 label_blog='Web Site'
-label_watchers='Stars'
+label_stargazers_count='Stars'
 label_homepage='Web Site'
 label_html_url='GitHub Page'
 label_ssh_url='Remote URL'

--- a/lib/git-hub.d/git-hub-repo
+++ b/lib/git-hub.d/git-hub-repo
@@ -28,7 +28,7 @@ ok:repo() {
     full_name description homepage language
     html_url ssh_url
     forks parent__full_name source__full_name
-    watchers open_issues pushed_at created_at
+    stargazers_count open_issues pushed_at created_at
     privatex
   )
   report-data


### PR DESCRIPTION
For legacy reasons the watchers of a repository are under the key
`subscribers_count`, and stars under `stargazers_count`.
`watchers` is still there reporting the stargazers.

But this is confusing when getting JSON output, especially for people who
never knew that watchers were stars previously.

```
% git hub repo ingydotnet/git-hub -j
{
    "full_name": "ingydotnet/git-hub",
    ...
    "watchers": 662,
    ...
}
% git hub repo ingydotnet/git-hub
Full Name       ingydotnet/git-hub
...
Stars           662
...
```

