### PR TITLE
Invalid JSON output: trailing comma in some cases

### DIFF
--- a/lib/git-hub.d/json-setup.bash
+++ b/lib/git-hub.d/json-setup.bash
@@ -86,18 +86,23 @@ pretty-json-list() {
 
   echo '['
   for (( i = 0; i <= $num; i++)); do
-    echo '  {'
+    local first_line=1
+    echo -n '  {'
     for (( j = 0; j < ${#keys[@]}; j++)); do
       local key="${keys[$j]}"
       local key="${key//__/\/}"
       local value="$(JSON.get "$key_prefix/$i/$key" - || true)"
       if [[ -n $value ]]; then
+        if (( $first_line )); then
+          echo ""
+        else
+          echo ","
+        fi
         printf "    \"%s\": %s" "$key" "$value"
-        [[ $(($j+1)) -lt ${#keys[@]} ]] && printf ','
-        printf "\n"
+        first_line=0
       fi
     done
-    printf '  }'
+    echo -n $'\n''  }'
     if [[ $i -lt $num ]]; then
       echo ,
     else
@@ -110,18 +115,23 @@ pretty-json-list() {
 pretty-json-object() {
   declare -a keys=("$@")
 
-  echo '{'
+  local first_line=1
+  echo -n '{'
   for (( i = 0; i < ${#keys[@]}; i++)); do
     local key="${keys[$i]}"
     local key="${key//__/\/}"
     local value="$(JSON.get "/$key" - || true)"
     if [[ -n $value ]]; then
+      if (( $first_line )); then
+        echo ""
+      else
+        echo ","
+      fi
       printf "    \"%s\": %s" "$key" "$value"
-      [[ $(($i+1)) -lt ${#keys[@]} ]] && printf ','
-      printf "\n"
+      first_line=0
     fi
   done
-  echo '}'
+  echo $'\n''}'
 }
 
 json-var-list() {


### PR DESCRIPTION
In some cases, `-j` will produce JSON with a trailing comma:

```
% git hub repo -j
{
    "full_name": "perlpunk/git-hub",
    "description": "Do GitHub operations from the `git` command",
    "language": "Shell",
    "html_url": "https://github.com/perlpunk/git-hub",
    "ssh_url": "git@github.com:perlpunk/git-hub.git",
    "forks": 0,
    "parent/full_name": "ingydotnet/git-hub",
    "source/full_name": "ingydotnet/git-hub",
    "watchers": 1,
    "open_issues": 0,
    "pushed_at": "2016-05-13T19:53:33Z",
    "created_at": "2015-06-02T19:31:17Z",
}
```

This happens because of a little mistake in the loop logic in
`lib/git-hub.d/json-setup.bash pretty-json-object()`

Without the check for `-n` this would be the last line:

```
    "privatex": 
```


