### PR TITLE
GIT_HUB_EDIT_MSG file logic broken for pr-new

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -1447,7 +1447,7 @@ Found existing $GIT_HUB_MSG_FILE from:
 
           r)
             # remove all comment lines
-            sed -i -e '/^#.*$/d' $GIT_HUB_MSG_FILE
+            sed -i -n '/^#/q;p' $GIT_HUB_MSG_FILE
             echo "$body" | sed -e '/^$/d' >> "$GIT_HUB_MSG_FILE"
             break
           ;;


### PR DESCRIPTION
I only remove lines starting with `#` when reusing an old msg file from a command that failed.
In case of pr-new it also contains the output of `git diff`, without `#`
