### PR TITLE
Follow symlinks when looking for lib files

### DIFF
--- a/lib/git-hub
+++ b/lib/git-hub
@@ -62,7 +62,15 @@ x           Debug - Turn on Bash trace (set -x) output
 "
 
 # source bash+ :std
-SELFDIR="$(cd -P `dirname $BASH_SOURCE` && pwd -P)"
+SELFFILE="$BASH_SOURCE"
+while [ -h "$SELFFILE" ]; do
+  SELFDIR=$(cd -P "$(dirname "$SELFFILE")" && pwd -P)
+  SELFFILE=$(readlink "$SELFFILE")
+  if [ "${SELFFILE:0:1}" != "/" ]; then
+    SELFFILE="$SELFDIR/$SELFFILE"
+  fi
+done
+SELFDIR=$(cd -P $(dirname "$SELFFILE") && pwd -P)
 source "$SELFDIR/git-hub.d/bash+.bash"
 bash+:import :std can
 


### PR DESCRIPTION
The previous logic would not handle the case when the executed 'git-hub' script itself was a symlink.

Yes, this looks bloated, but I found no better portable solution.