### PR TITLE
Improvements for `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,13 @@ EXTS = $(shell find $(EXT) -type f) \
 	$(shell find $(EXT) -type l)
 SHARE = share
 
-# XXX Make these vars look like git.git/Makefile style
-PREFIX ?= /usr/local
 # XXX Using sed for now. Would like to use bash or make syntax.
 # If GIT_EXEC_PATH is set, `git --exec-path` will contain that appended to the
 # front. We just want the path where git is actually installed:
 INSTALL_LIB ?= $(shell git --exec-path | sed 's/.*://')
 INSTALL_CMD ?= $(INSTALL_LIB)/$(NAME)
 INSTALL_EXT ?= $(INSTALL_LIB)/$(NAME).d
-INSTALL_MAN1 ?= $(PREFIX)/share/man/man1
+INSTALL_MAN1 ?= $(shell git --man-path | sed 's/.*://')/man1
 
 ##
 # User targets:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # Make sure we have 'git' and it works OK:
+ifeq ($(NO_GIT_CHECK),)
 ifeq ($(shell which git),)
     $(error 'git' is not installed on this system)
 endif
 GITVER ?= $(word 3,$(shell git --version))
+endif
 
 NAME = git-hub
 LIB = lib

--- a/Makefile
+++ b/Makefile
@@ -47,25 +47,25 @@ endif
 
 install: install-lib install-doc
 
-install-lib: $(INSTALL_EXT)
-	install -C -m 0755 $(LIBS) $(INSTALL_LIB)/
-	install -d -m 0755 $(INSTALL_EXT)/
-	install -C -m 0755 $(EXTS) $(INSTALL_EXT)/
+install-lib: $(DESTDIR)$(INSTALL_EXT)
+	install -C -m 0755 $(LIBS) $(DESTDIR)$(INSTALL_LIB)/
+	install -d -m 0755 $(DESTDIR)$(INSTALL_EXT)/
+	install -C -m 0755 $(EXTS) $(DESTDIR)$(INSTALL_EXT)/
 
 install-doc:
-	install -d -m 0755 $(INSTALL_MAN1)
-	install -C -m 0644 $(MAN) $(INSTALL_MAN1)
+	install -d -m 0755 $(DESTDIR)$(INSTALL_MAN1)
+	install -C -m 0644 $(MAN) $(DESTDIR)$(INSTALL_MAN1)
 
 uninstall: uninstall-lib uninstall-doc
 
 uninstall-lib:
-	rm -f $(INSTALL_CMD)
-	rm -fr $(INSTALL_EXT)
+	rm -f $(DESTDIR)$(INSTALL_CMD)
+	rm -fr $(DESTDIR)$(INSTALL_EXT)
 
 uninstall-doc:
-	rm -f $(INSTALL_MAN1)/$(NAME).1
+	rm -f $(DESTDIR)$(INSTALL_MAN1)/$(NAME).1
 
-$(INSTALL_EXT):
+$(DESTDIR)$(INSTALL_EXT):
 	mkdir -p $@
 
 clean purge:


### PR DESCRIPTION
  * Support the `DESTDIR` variable
  * Install the man page to the same location where git installed its man pages
  * Allow to skip the check for git, which is useful when setting `INSTALL_LIB` and `INSTALL_MAN` anyway