### PR TITLE
Add location of completion script on MacOS with brew

### DIFF
--- a/doc/git-hub.swim
+++ b/doc/git-hub.swim
@@ -683,6 +683,7 @@ following locations (or somewhere else that we don't know about):
 * `/usr/share/bash-completion/completions/git`
 * `/opt/local/share/bash-completion/completions/git`
 * `/usr/local/etc/bash_completion.d/git`
+* `/usr/local/opt/git/share/git-core/contrib/completion`
 * `~/.homebrew/etc/bash_completion.d/git`
 
 In case you can't find any of these, this repository contains a copy of the


### PR DESCRIPTION
On MacOS Sierra 10.12.2, the git completion scripts are located in
`/usr/local/opt/git/share/git-core/contrib/completion`.

```Shell
cd /usr/local/opt/git/share/git-core/contrib/completion
pwd -P
      /usr/local/Cellar/git/2.11.0/share/git-core/contrib/completion

ls
    git-completion.bash git-completion.tcsh git-completion.zsh  git-prompt.sh
```

Thank you @ingydotnet  for _git-hub_, it is very useful.