### PR TITLE
pr-list: Mark drafts with gray color

### DIFF
--- a/lib/git-hub.d/git-hub-issue
+++ b/lib/git-hub.d/git-hub-issue
@@ -86,6 +86,7 @@ ok:issue() {
     html_url
     user__login
     state
+    draft
     assignee__login
     milestone__title
     created_at body

--- a/lib/git-hub.d/git-hub-pr
+++ b/lib/git-hub.d/git-hub-pr
@@ -98,21 +98,26 @@ command:pr-list() {
 
   report-list \
     "/repos/$owner/$repo/pulls?state=$state;sort=updated;direction=desc;per_page=PER_PAGE" \
-    'number state title user/login created_at updated_at head/label base/label html_url'
+    'number state title user/login created_at updated_at head/label base/label html_url draft'
 }
 
 format-entry:pr-list() {
   local number=$2 state=$3 title=$4 creator=$5 created=$6 updated=$7
-  local head=$8 base=$9 url=${10}
+  local head=$8 base=$9 url=${10} draft=${11} statecolor=YELLOW
   if "$raw_output"; then
     local repo=$url
     repo="${url#https\:\/\/github\.com\/}"
     repo="${repo%\/pull\/[[:digit:]]*}"
     printf "$repo\t$number\n"
   else
+
+    if $draft; then
+      state="$state/draft"
+      statecolor=DARKGRAY
+    fi
     color-table-row \
       "#%-3d" LABEL "$number" \
-      "%-8s"  YELLOW "($state)" \
+      "%-8s"  $statecolor "($state)" \
       ""      "" "$title"
     color-table-row \
       "     @%-12s" LOGIN "$creator" \


### PR DESCRIPTION


Currently `pr-list` gives no hint if a PR is a draft or not.
With this PR the status will be in gray and have `draft` appended.
![show-draft-screenshot](https://user-images.githubusercontent.com/688850/114322526-01b81780-9b21-11eb-9699-22450fe47b87.png)
